### PR TITLE
Refactor game start logic to use client loop utility

### DIFF
--- a/backend/src/routers/host/events/attempGameStart.ts
+++ b/backend/src/routers/host/events/attempGameStart.ts
@@ -1,5 +1,4 @@
 import type { Socket } from "socket.io";
-import type { lobbyData } from "utils/types";
 
 import lobbyService from "services/lobby";
 import specialKey from "services/specialKey";
@@ -9,31 +8,22 @@ import sharedEnums from "shared/enums";
 const serverTSRemotes = sharedEnums.serverToStationRemotes
 const serverTCRemotes = sharedEnums.serverToClientRemotes
 
-function getAllRegisteredKeys(lobbyData: lobbyData) {
+function alertAllGameStarting() {
     let allRegisteredKeys = [];
 
-    for (const client of lobbyData.clients) {
-        const clientKey = specialKey.getKeyByConnection(client);
+    lobbyService.loopThroughClients((client) => {
+        const clientKey = specialKey.getKeyByConnection(client)
+        if (!clientKey) return
+
+        client.socket.emit(serverTCRemotes.gameStarted, clientKey)
         allRegisteredKeys.push(clientKey);
-    }
+    })
 
-    return allRegisteredKeys;
-}
-
-function alertAllStationsGameStarting(availableKeys: string[]) {
-    lobbyService.emitToAllStations(serverTSRemotes.gameStarted, availableKeys)
-}
-
-function alertAllClientGameStarting() {
-    lobbyService.emitToAllClients(serverTCRemotes.gameStarted)
+    lobbyService.emitToAllStations(serverTSRemotes.gameStarted, allRegisteredKeys)
 }
 
 function attemptGameStart(hostSocket: Socket) {
-    const lobbyData = lobbyService.getLobbyData()
-    const registeredKeys = getAllRegisteredKeys(lobbyData)
-
-    alertAllStationsGameStarting(registeredKeys)
-    alertAllClientGameStarting()
+    alertAllGameStarting()
 }
 
 export default attemptGameStart

--- a/backend/src/services/lobby.ts
+++ b/backend/src/services/lobby.ts
@@ -66,6 +66,12 @@ function connectStationToLobby(stationConnection: socketConnection): void {
     currentLobbyData.stations.push(stationConnection)
 }
 
+function loopThroughClients(callback: (client: socketConnection) => void) {
+    for (const client of currentLobbyData.clients) {
+        callback(client)
+    }
+}
+
 function emitToAllClients(eventName: string, ...args: any[]): void {
     for (const client of currentLobbyData.clients) {
         client.socket.emit(eventName, ...args)
@@ -78,4 +84,4 @@ function emitToAllStations(eventName: string, ...args: any[]): void {
     }  
 }
 
-export default { generateLobbyCode, lobbyExists, createLobby, getLobbyData, isConnectionRegistered, getLobbyCode, connectClientToLobby, connectStationToLobby, emitToAllClients, emitToAllStations }
+export default { generateLobbyCode, lobbyExists, createLobby, getLobbyData, isConnectionRegistered, getLobbyCode, connectClientToLobby, connectStationToLobby, emitToAllClients, emitToAllStations, loopThroughClients }


### PR DESCRIPTION
Replaces manual client iteration in attempGameStart with a new loopThroughClients utility in lobbyService. Now emits gameStarted events to clients with their keys and to stations with all registered keys, simplifying and consolidating the notification logic.