### PR TITLE
Add recipe generation logic and shared food/station data

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "backend",
       "dependencies": {
         "express": "^5.1.0",
         "http": "^0.0.1-security",
@@ -106,6 +105,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
       "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -1346,6 +1346,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,22 +21,30 @@ httpServer.listen(sharedEnums.portServer.port, () => {
     console.log(`Backend server running on http://localhost:${sharedEnums.portServer.port}`)
 })
 
-// For testing purposes only
-// import { io } from "socket.io-client"
+import { io } from "socket.io-client"
 
-// const authData = { auth: { intendedRole: 'host', lobbyCode: "ABCDEF" } }
-// const clientSocketHost = io(`http://localhost:${sharedEnums.portServer.port}`, authData)
+const handshakeDataHost = { auth: { intendedRole: 'host', lobbyCode: "ABCDEF" } }
+const clientSocketHost = io(`http://localhost:${sharedEnums.portServer.port}`, handshakeDataHost)
 
-// clientSocketHost.on("connect_error", (err) => {
-//     console.log(`Connection error: ${err.message}`)
-// })
+clientSocketHost.on(sharedEnums.sharedRemotes.connectError, (err) => {
+    console.log(`Connection error: ${err.message}`)
+})
 
-// const clientSocketClient = io(`http://localhost:${sharedEnums.portServer.port}`, { auth: { intendedRole: 'client', lobbyCode: "ABCDEF" } })
+const handshakeDataClient = { auth: { intendedRole: 'station', lobbyCode: "ABCDEF" } }
+const clientSocketClient = io(`http://localhost:${sharedEnums.portServer.port}`, handshakeDataClient)
 
-// clientSocketHost.on(sharedEnums.serverToHostRemotes.clientPendingJoin, (data: any) => {
-//     clientSocketHost.emit(sharedEnums.hostToServerRemotes.acceptClientJoin, data.identifier)
-// })
+clientSocketHost.on(sharedEnums.serverToHostRemotes.clientPendingJoin, (data: any) => {
+    clientSocketHost.emit(sharedEnums.hostToServerRemotes.acceptClientJoin, data.identifier)
+})
 
-// clientSocketClient.on(sharedEnums.serverToClientRemotes.clientAccepted, (specialKey: string) => {
-//     console.log(`Client accepted with special key: ${specialKey}`)
-// })  
+clientSocketClient.on(sharedEnums.serverToClientRemotes.clientAccepted, (specialKey: string) => {
+    console.log(`Client accepted with special key: ${specialKey}`)
+})
+
+clientSocketClient.on(sharedEnums.sharedRemotes.connectError, (err) => {
+    console.log(`Connection error: ${err.message}`)
+})
+
+clientSocketClient.on(sharedEnums.sharedRemotes.connect, () => {
+    console.log("Client connected successfully")
+})

--- a/backend/src/routers/host/events/onAcceptStation.ts
+++ b/backend/src/routers/host/events/onAcceptStation.ts
@@ -1,23 +1,27 @@
-import type { uniqueIdentifier, availableStations } from "shared/types"
+import type { uniqueIdentifier } from "shared/types"
 import type { Socket } from "socket.io"
 
 import socketRegistry from "services/socketRegistry"
 import lobbyService from "services/lobby"
 import sharedEnums from "shared/enums"
 
+import singletons from "utils/singletons"
+
 const serverToHostRemotes = sharedEnums.serverToHostRemotes
 const serverToStationRemotes = sharedEnums.serverToStationRemotes
 
-function onAcceptStation(hostSocket: Socket, identifier: uniqueIdentifier, stationName: availableStations) {
+function onAcceptStation(hostSocket: Socket, identifier: uniqueIdentifier, stationName: string) {
     const stationConnection = socketRegistry.getSocketConnectionById(identifier)
     if (!stationConnection) { console.log("Station connection not found"); return }
-    
+
     const isStationInLobby = lobbyService.isConnectionRegistered(stationConnection)
     if (!isStationInLobby) { console.log("Station not in lobby"); return }
 
     lobbyService.connectStationToLobby(stationConnection)
     hostSocket.emit(serverToHostRemotes.newStationJoined, identifier)
     stationConnection.socket.emit(serverToStationRemotes.stationAssigned, stationName)
+
+    singletons.recipeGenerator.RefreshMethods()
 }
 
 export default onAcceptStation

--- a/backend/src/utils/Singletons/recipeGenerator.ts
+++ b/backend/src/utils/Singletons/recipeGenerator.ts
@@ -1,0 +1,56 @@
+import { internalFoodData, internalStationData } from "shared/types"
+
+import lobbyService from "services/lobby"
+import sharedData from "shared/data"
+
+let availableMethods: Record<string, true> = {}
+
+function RefreshMethods() {
+    const lobbyData = lobbyService.getLobbyData()
+    if (!lobbyData.stationData) { return }
+
+    availableMethods = {}
+
+    for (const stationData of Object.values(lobbyData.stationData)) {
+        const internalStationData: internalStationData | undefined = stationData[stationData.stationType]
+        if (!internalStationData) { continue }
+
+        const method = internalStationData.method
+        if (!method || method === "") { continue }
+
+        availableMethods[method] = true
+    }
+}
+
+function ShouldConsiderAsRecipe(foodValue: internalFoodData) {
+    const couldBeActiveRecipe = foodValue.couldBeActiveRecipe
+    if (!couldBeActiveRecipe) { return false }
+
+    let hasAvailableMethod = false
+
+    for (const method of Object.keys(foodValue.methods)) {
+        if (availableMethods[method]) { hasAvailableMethod = true; break }
+    }
+
+    return hasAvailableMethod
+}
+
+function GenerateRecipe(): string {
+    const possibleRecipes: string[] = []
+
+    for (const [foodKey, foodValue] of Object.entries(sharedData.foodData)) {
+        const shouldConsiderAsRecipe = ShouldConsiderAsRecipe(foodValue)
+        if (!shouldConsiderAsRecipe) { continue }
+
+        possibleRecipes.push(foodKey)
+    }
+
+    if (possibleRecipes.length === 0) { throw new Error("No possible recipes could be generated") }
+
+    const randomIndex = Math.floor(Math.random() * possibleRecipes.length)
+    const randomlyPickedRecipe = possibleRecipes[randomIndex]
+
+    return randomlyPickedRecipe
+}
+
+export default { RefreshMethods, GenerateRecipe }

--- a/backend/src/utils/singletons.ts
+++ b/backend/src/utils/singletons.ts
@@ -1,0 +1,5 @@
+import recipeGenerator from "./Singletons/recipeGenerator";
+
+export default {
+    recipeGenerator
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,20 +1,31 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
-
         "paths": {
-            "shared/*": ["../shared/src/*"],
-            "services/*": ["./src/services/*"],
-            "routers/*": ["./src/routers/*"],
-            "utils/*": ["./src/utils/*"]
+            "shared/*": [
+                "../shared/src/*"
+            ],
+            "services/*": [
+                "./src/services/*"
+            ],
+            "routers/*": [
+                "./src/routers/*"
+            ],
+            "utils/*": [
+                "./src/utils/*"
+            ]
         },
-
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "lib": [
+            "ES2017",
+            "DOM"
+        ]
     },
-
     "ts-node": {
-        "require": ["tsconfig-paths/register"]
+        "require": [
+            "tsconfig-paths/register"
+        ]
     },
 }

--- a/shared/src/data.ts
+++ b/shared/src/data.ts
@@ -1,1 +1,7 @@
-import type { availableMethods, } from "./types"
+import foodData from "./data/foodData";
+import stationData from "./data/stationData"
+
+export default {
+    foodData,
+    stationData
+}

--- a/shared/src/data/foodData.ts
+++ b/shared/src/data/foodData.ts
@@ -1,0 +1,23 @@
+import sharedEnums from "../enums"
+import type { internalFoodData } from "../types"
+
+const foods = sharedEnums.foods
+const methods = sharedEnums.methods
+
+const foodData: Record<string, internalFoodData> = {
+    [foods.uncookedEgg]: {
+        name: "Uncooked Egg",
+        methods: { [methods.boil]: foods.boiledEgg },
+        combinations: {},
+        couldBeActiveRecipe: false
+    },
+
+    [foods.boiledEgg]: {
+        name: "Boiled Egg",
+        methods: {},
+        combinations: {},
+        couldBeActiveRecipe: true
+    }
+}
+
+export default foodData

--- a/shared/src/data/stationData.ts
+++ b/shared/src/data/stationData.ts
@@ -1,0 +1,12 @@
+import sharedEnums from "../enums"
+import type { internalStationData } from "../types"
+
+const methods = sharedEnums.methods
+const stationsTypes = sharedEnums.stationTypes
+
+const stationData: Record<string, internalStationData> = {
+    [stationsTypes.empty]: { method: "" },
+    [stationsTypes.boilingStation]: { method: methods.boil }
+}
+
+export default stationData

--- a/shared/src/enums.ts
+++ b/shared/src/enums.ts
@@ -26,6 +26,8 @@ enum serverToStationRemotes {
 }
 
 enum sharedRemotes {
+    connect = "connect",
+    connectError = "connect_error",
     hostRejectedConnection = "hostRejectedConnection"
 }
 
@@ -46,13 +48,32 @@ enum connValidatorErrors {
     otherConnectionsFailed = "No lobby with provided code exists."
 }
 
+enum stationTypes {
+    empty = "empty",
+    boilingStation = "boilingStation"
+}
+
+enum foods {
+    uncookedEgg = "uncookedEgg",
+    boiledEgg = "boiledEgg"
+}
+
+enum methods {
+    boil = "boil"
+}
+
 export default {
     hostToServerRemotes,
     serverToHostRemotes,
     serverToClientRemotes,
     serverToStationRemotes,
+    connValidatorErrors,
+
     sharedRemotes,
     portServer,
-    connValidatorErrors,
-    gameRoles
+    gameRoles,
+
+    stationTypes,
+    methods,
+    foods
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,23 +1,27 @@
 export type uniqueIdentifier = number
 
 export type intendedRoles = 'host' | 'client' | 'station'
-export type availableStations = 'empty'
 
 export type handshakeData = {
     intendedRole: intendedRoles,
     lobbyCode?: string
 }
 
-export type availableMethods = 'boil'
-
-export type foodItem = {
+export type internalFoodData = {
     name: string,
-    quality: number,
 
-    methods: Record<availableMethods, string>,
+    methods: Record<string, string>,
     combinations: Record<string, string>,
+    couldBeActiveRecipe: boolean,
+}
 
+export type foodItem = internalFoodData & {
+    quality: number,
     id: uniqueIdentifier,
+}
+
+export type internalStationData = {
+    method: string
 }
 
 export type activeRecipe = {
@@ -26,7 +30,7 @@ export type activeRecipe = {
 }
 
 export type stationData = {
-    stationType: availableStations,
+    stationType: string,
     currentFoodItem?: foodItem
 }
 


### PR DESCRIPTION
Introduces a recipeGenerator singleton for generating recipes based on available station methods. Adds shared foodData and stationData modules, updates enums and types to support new food and station concepts, and refactors backend and shared code to utilize these new structures. Also updates test logic in backend index and improves TypeScript configuration.